### PR TITLE
Replaced `docker fetch` with `docker pull` in install doc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,7 +452,7 @@ sudo gem install sequenceserver
           </p>
 
 {% highlight shell %}
-docker fetch wurmlab/sequenceserver
+docker pull wurmlab/sequenceserver
 {% endhighlight %}
 
           <div class="page-header">


### PR DESCRIPTION
Updated install docs to replace the nonexistent `docker fetch` command with `docker pull`.